### PR TITLE
feat: 축제 상세 페이지 리뷰 섹션 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
-        "@types/react": "^19",
+        "@types/react": "^19.2.14",
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
-    "@types/react": "^19",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,8 @@ export default function Home() {
   return (
     <main className="p-8">
       <h1 className="text-2xl font-bold mb-6">전국 축제 지도</h1>
-      <div className="border shadow-lg rounded-xl overflow-hidden">
-        <FestivalMap />
+      <div className="order shadow-lg rounded-xl overflow-hidden h-[750px]">
+        <FestivalMap radiusKm={100} />
       </div>
     </main>
   );

--- a/src/components/FestivalMap.tsx
+++ b/src/components/FestivalMap.tsx
@@ -23,6 +23,11 @@ export default function FestivalMap({ radiusKm }: FestivalMapProps) {
     const [markers, setMarkers] = useState<any[]>([]);
 
     const fetchNearbyFestivals = async (lat: number, lng: number, r: number) => {
+        if (typeof r !== "number" || Number.isNaN(r)) {
+            console.warn("Invalid radiusKm for festival fetch", r);
+            return;
+        }
+
         try {
             const response = await fetch(`/api/festivals/nearby?mapX=${lng}&mapY=${lat}&radiusKm=${r}`);
             const resData = await response.json();

--- a/src/types/react-kakao-maps-sdk.d.ts
+++ b/src/types/react-kakao-maps-sdk.d.ts
@@ -1,0 +1,18 @@
+declare module "react-kakao-maps-sdk" {
+  import type { ComponentType } from "react";
+
+  export const Map: ComponentType<any>;
+  export const MapMarker: ComponentType<any>;
+  export const ZoomControl: ComponentType<any>;
+  export function useKakaoLoader(options: {
+    appkey: string;
+    libraries?: string[];
+    defer?: boolean;
+  }): [boolean, Error | null];
+  export default {
+    Map,
+    MapMarker,
+    ZoomControl,
+    useKakaoLoader,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.d.ts",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     "**/*.mts"


### PR DESCRIPTION
## 작업 내용
- 축제 상세 페이지의 리뷰 섹션을 백엔드 리뷰 API와 연동했습니다.
- 리뷰 목록 조회 기능을 추가했습니다.
- 리뷰 작성 모달을 추가했습니다.
- 본인 리뷰에 한해 수정/삭제 기능을 연결했습니다.
- 리뷰가 없을 때의 빈 상태와 페이지네이션을 반영했습니다.
- 축제 조회 시 `radiusKm` 값이 비정상일 경우 요청하지 않도록 방어 로직을 추가했습니다.

## 변경 사항
- `src/app/festivals/[id]/page.tsx`
  - 기존 상세 페이지 구조는 유지 리뷰 섹션에만 API를 연결했습니다.
- `src/types/react-kakao-maps-sdk.d.ts`
  - `Map`, `MapMarker`, `ZoomControl`, `useKakaoLoader` 타입 선언을 추가했습니다.
- 축제 목록/지도 조회 로직
  - `radiusKm`이 숫자가 아닐 경우 경고를 남기고 fetch를 중단하도록 처리했습니다

## 확인 사항
- 축제 상세 페이지 진입 시 리뷰 목록이 정상 조회되는지
- 리뷰 작성 버튼 클릭 시 모달이 열리는지
- 로그인 사용자 기준으로 리뷰 작성/수정/삭제가 정상 동작하는지
- 리뷰가 없을 때 빈 상태 메시지가 보이는지