### PR TITLE
Feature/festival sync fix

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -225,7 +225,7 @@ export default function AdminPage() {
 
         try {
             const response = await fetch(
-                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=300&eventStartDate=20260101`,
+                `http://localhost:8080/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=200&eventStartDate=20260101`,
                 {
                     method: "POST",
                     headers: {
@@ -253,11 +253,11 @@ export default function AdminPage() {
                 if (latestStatus) {
                     if (latestStatus.pendingCount === 0) {
                         setFestivalActionError(
-                            "응답 처리 중 오류가 발생했지만, 현재 동기화 상태는 정상입니다."
+                            "응답을 정상적으로 받지 못했지만, 현재 상세 동기화 미완료 대상은 없습니다. 동기화는 정상 반영되었을 수 있습니다."
                         );
                     } else {
                         setFestivalActionError(
-                            "응답 처리 중 오류가 발생했으며, 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
+                            "응답을 정상적으로 받지 못했지만, 현재 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
                         );
                     }
                 } else {
@@ -278,11 +278,11 @@ export default function AdminPage() {
             if (latestStatus) {
                 if (latestStatus.pendingCount === 0) {
                     setFestivalActionError(
-                        "응답 처리 중 오류가 발생했지만, 현재 동기화 상태는 정상입니다."
+                        "응답을 정상적으로 받지 못했지만, 현재 상세 동기화 미완료 대상은 없습니다. 동기화는 정상 반영되었을 수 있습니다."
                     );
                 } else {
                     setFestivalActionError(
-                        "응답 처리 중 오류가 발생했으며, 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
+                        "응답을 정상적으로 받지 못했지만, 현재 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
                     );
                 }
             } else {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -190,6 +190,25 @@ export default function AdminPage() {
         }
     };
 
+    //축제 데이터 동기화 간, 공통 안전 파싱 함수 추가
+    const parseApiResponse = async (response: Response) => {
+        const raw = await response.text();
+
+        let body: any = null;
+        let isJson = false;
+
+        try {
+            body = raw ? JSON.parse(raw) : null;
+            isJson = true;
+        } catch {
+            body = null;
+            isJson = false;
+        }
+
+        return { raw, body, isJson };
+    };
+
+
     //축제 관리자 API 연결 함수 추가
     const runFestivalSyncAndEnrich = async () => {
         setFestivalActionLoading(true);
@@ -206,7 +225,7 @@ export default function AdminPage() {
 
         try {
             const response = await fetch(
-                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=300&eventStartDate=20260101`,
+                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=100&eventStartDate=20260101`,
                 {
                     method: "POST",
                     headers: {
@@ -216,20 +235,24 @@ export default function AdminPage() {
                 }
             );
 
-            const body = await response.json();
+            const { raw, body } = await parseApiResponse(response);
 
             if (response.ok) {
                 setLastFestivalAction("sync");
-                setFestivalActionMessage(body.message || "축제 목록 동기화가 완료되었습니다.");
-                setFestivalSyncResult(body.data ?? null);
+                setFestivalActionMessage(body?.message || "축제 목록 동기화가 완료되었습니다.");
+                setFestivalSyncResult(body?.data ?? null);
                 void fetchFestivalSyncStatus({ clearResult: false });
             } else {
-                setFestivalActionError(body.message || "축제 동기화 실행에 실패했습니다.");
+                setFestivalActionError(
+                    body?.message || raw || "축제 동기화 실행에 실패했습니다."
+                );
                 setFestivalSyncResult(null);
             }
         } catch (error) {
             console.error("축제 동기화 실행 오류:", error);
-            setFestivalActionError("서버 통신 중 오류가 발생했습니다.");
+            setFestivalActionError(
+                error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
+            );
             setFestivalSyncResult(null);
         } finally {
             setFestivalActionLoading(false);
@@ -258,20 +281,24 @@ export default function AdminPage() {
                 },
             });
 
-            const body = await response.json();
+            const { raw, body } = await parseApiResponse(response);
 
             if (response.ok) {
                 setLastFestivalAction("retry");
-                setFestivalActionMessage(body.message || "축제 상세 보강 재처리가 완료되었습니다.");
-                setFestivalSyncResult(body.data ?? null);
+                setFestivalActionMessage(body?.message || "축제 상세 보강 재처리가 완료되었습니다.");
+                setFestivalSyncResult(body?.data ?? null);
                 void fetchFestivalSyncStatus({ clearResult: false });
             } else {
-                setFestivalActionError(body.message || "축제 상세 재처리에 실패했습니다.");
+                setFestivalActionError(
+                    body?.message || raw || "축제 상세 재처리에 실패했습니다."
+                );
                 setFestivalSyncResult(null);
             }
         } catch (error) {
             console.error("축제 상세 재처리 오류:", error);
-            setFestivalActionError("서버 통신 중 오류가 발생했습니다.");
+            setFestivalActionError(
+                error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
+            );
             setFestivalSyncResult(null);
         } finally {
             setFestivalActionLoading(false);
@@ -307,18 +334,22 @@ export default function AdminPage() {
                     },
                 });
 
-                const body = await response.json();
+                const { raw, body } = await parseApiResponse(response);
 
                 if (response.ok) {
-                    setFestivalActionMessage(body.message || "동기화 상태 조회가 완료되었습니다.");
-                    setFestivalSyncStatus(body.data ?? null);
+                    setFestivalActionMessage(body?.message || "동기화 상태 조회가 완료되었습니다.");
+                    setFestivalSyncStatus(body?.data ?? null);
                 } else {
-                    setFestivalActionError(body.message || "동기화 상태 조회에 실패했습니다.");
+                    setFestivalActionError(
+                        body?.message || raw || "동기화 상태 조회에 실패했습니다."
+                    );
                     setFestivalSyncStatus(null);
                 }
             } catch (error) {
                 console.error("축제 동기화 상태 조회 오류:", error);
-                setFestivalActionError("서버 통신 중 오류가 발생했습니다.");
+                setFestivalActionError(
+                    error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
+                );
                 setFestivalSyncStatus(null);
             } finally {
                 setFestivalActionLoading(false);

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -225,7 +225,7 @@ export default function AdminPage() {
 
         try {
             const response = await fetch(
-                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=100&eventStartDate=20260101`,
+                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=300&eventStartDate=20260101`,
                 {
                     method: "POST",
                     headers: {
@@ -241,19 +241,55 @@ export default function AdminPage() {
                 setLastFestivalAction("sync");
                 setFestivalActionMessage(body?.message || "축제 목록 동기화가 완료되었습니다.");
                 setFestivalSyncResult(body?.data ?? null);
-                void fetchFestivalSyncStatus({ clearResult: false });
+                void fetchFestivalSyncStatus({ clearResult: false, silent: true });
             } else {
-                setFestivalActionError(
-                    body?.message || raw || "축제 동기화 실행에 실패했습니다."
-                );
                 setFestivalSyncResult(null);
+
+                const latestStatus = await fetchFestivalSyncStatus({
+                    clearResult: false,
+                    silent: true,
+                });
+
+                if (latestStatus) {
+                    if (latestStatus.pendingCount === 0) {
+                        setFestivalActionError(
+                            "응답 처리 중 오류가 발생했지만, 현재 동기화 상태는 정상입니다."
+                        );
+                    } else {
+                        setFestivalActionError(
+                            "응답 처리 중 오류가 발생했으며, 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
+                        );
+                    }
+                } else {
+                    setFestivalActionError(
+                        body?.message || raw || "축제 동기화 실행에 실패했습니다."
+                    );
+                }
             }
         } catch (error) {
             console.error("축제 동기화 실행 오류:", error);
-            setFestivalActionError(
-                error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
-            );
             setFestivalSyncResult(null);
+
+            const latestStatus = await fetchFestivalSyncStatus({
+                clearResult: false,
+                silent: true,
+            });
+
+            if (latestStatus) {
+                if (latestStatus.pendingCount === 0) {
+                    setFestivalActionError(
+                        "응답 처리 중 오류가 발생했지만, 현재 동기화 상태는 정상입니다."
+                    );
+                } else {
+                    setFestivalActionError(
+                        "응답 처리 중 오류가 발생했으며, 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
+                    );
+                }
+            } else {
+                setFestivalActionError(
+                    error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
+                );
+            }
         } finally {
             setFestivalActionLoading(false);
         }
@@ -306,11 +342,15 @@ export default function AdminPage() {
     };
 
     const fetchFestivalSyncStatus = useCallback(
-        async (options?: { clearResult?: boolean }) => {
+        async (options?: { clearResult?: boolean; silent?: boolean }) => {
             const clearResult = options?.clearResult ?? false;
+            const silent = options?.silent ?? false;
 
             setFestivalActionLoading(true);
-            setFestivalActionError(null);
+
+            if (!silent) {
+                setFestivalActionError(null);
+            }
 
             if (clearResult) {
                 setFestivalSyncResult(null);
@@ -322,7 +362,7 @@ export default function AdminPage() {
             if (!accessToken) {
                 alert("로그인이 필요합니다.");
                 window.location.href = "/login";
-                return;
+                return null;
             }
 
             try {
@@ -337,20 +377,34 @@ export default function AdminPage() {
                 const { raw, body } = await parseApiResponse(response);
 
                 if (response.ok) {
-                    setFestivalActionMessage(body?.message || "동기화 상태 조회가 완료되었습니다.");
-                    setFestivalSyncStatus(body?.data ?? null);
+                    const statusData = body?.data ?? null;
+                    setFestivalSyncStatus(statusData);
+
+                    if (!silent) {
+                        setFestivalActionMessage(body?.message || "동기화 상태 조회가 완료되었습니다.");
+                    }
+
+                    return statusData;
                 } else {
-                    setFestivalActionError(
-                        body?.message || raw || "동기화 상태 조회에 실패했습니다."
-                    );
+                    if (!silent) {
+                        setFestivalActionError(
+                            body?.message || raw || "동기화 상태 조회에 실패했습니다."
+                        );
+                    }
                     setFestivalSyncStatus(null);
+                    return null;
                 }
             } catch (error) {
                 console.error("축제 동기화 상태 조회 오류:", error);
-                setFestivalActionError(
-                    error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
-                );
+
+                if (!silent) {
+                    setFestivalActionError(
+                        error instanceof Error ? error.message : "서버 통신 중 오류가 발생했습니다."
+                    );
+                }
+
                 setFestivalSyncStatus(null);
+                return null;
             } finally {
                 setFestivalActionLoading(false);
             }
@@ -566,7 +620,7 @@ export default function AdminPage() {
                     <div className="animate-in fade-in duration-300">
                         <div className="mb-6 flex items-center justify-between">
                             <h2 className="text-2xl font-bold text-slate-800">축제 데이터 관리</h2>
-                            <span className="text-sm text-slate-500">동기화 및 상세 재처리 관리</span>
+                            <span className="text-sm text-slate-500">목록 데이터 동기화 및 상세 재처리 관리</span>
                         </div>
 
                         <div className="space-y-6">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -223,17 +223,23 @@ export default function AdminPage() {
             return;
         }
 
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 600000); // 10분, 프론트 최대 대기시간
+
         try {
             const response = await fetch(
-                `http://localhost:8080/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=200&eventStartDate=20260101`,
+                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=100&eventStartDate=20260101`,
                 {
                     method: "POST",
                     headers: {
                         Authorization: `Bearer ${accessToken}`,
                         Accept: "application/json",
                     },
+                    signal: controller.signal,
                 }
             );
+
+            clearTimeout(timeoutId);
 
             const { raw, body } = await parseApiResponse(response);
 
@@ -267,6 +273,7 @@ export default function AdminPage() {
                 }
             }
         } catch (error) {
+            clearTimeout(timeoutId);
             console.error("축제 동기화 실행 오류:", error);
             setFestivalSyncResult(null);
 
@@ -275,7 +282,21 @@ export default function AdminPage() {
                 silent: true,
             });
 
-            if (latestStatus) {
+            if (error instanceof DOMException && error.name === "AbortError") {
+                if (latestStatus) {
+                    if (latestStatus.pendingCount === 0) {
+                        setFestivalActionError(
+                            "요청 시간이 초과되었지만, 현재 상세 동기화 미완료 대상은 없습니다. 동기화는 정상 반영되었을 수 있습니다."
+                        );
+                    } else {
+                        setFestivalActionError(
+                            "요청 시간이 초과되었으며, 현재 상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."
+                        );
+                    }
+                } else {
+                    setFestivalActionError("요청 시간이 초과되었습니다. 현재 동기화 상태를 확인해주세요.");
+                }
+            } else if (latestStatus) {
                 if (latestStatus.pendingCount === 0) {
                     setFestivalActionError(
                         "응답을 정상적으로 받지 못했지만, 현재 상세 동기화 미완료 대상은 없습니다. 동기화는 정상 반영되었을 수 있습니다."
@@ -291,6 +312,7 @@ export default function AdminPage() {
                 );
             }
         } finally {
+            clearTimeout(timeoutId);
             setFestivalActionLoading(false);
         }
     };

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -43,12 +43,34 @@ type ReportedReviewPageResponse = {
     totalPages: number;
 };
 
+// 축제 관련 타입 정의
+type FestivalSyncResponse = {
+    totalCount: number;
+    createdCount: number;
+    updatedCount: number;
+    failedCount: number;
+};
+
+type FestivalSyncStatusResponse = {
+    pendingCount: number;
+    pendingBreakdown: Record<string, number>;
+    needsRetry: boolean;
+};
+
 export default function AdminPage() {
     const [activeTab, setActiveTab] = useState("members");
     const [memberFilter, setMemberFilter] = useState<"all" | "reported">("all");
     const [loading, setLoading] = useState(true);
     const [memberData, setMemberData] = useState<MemberPageResponse | null>(null);
     const [reviewData, setReviewData] = useState<ReportedReviewPageResponse | null>(null);
+
+    const [festivalActionLoading, setFestivalActionLoading] = useState(false);
+    const [festivalActionMessage, setFestivalActionMessage] = useState<string | null>(null);
+    const [festivalActionError, setFestivalActionError] = useState<string | null>(null);
+    const [festivalSyncResult, setFestivalSyncResult] = useState<FestivalSyncResponse | null>(null);
+    const [festivalSyncStatus, setFestivalSyncStatus] = useState<FestivalSyncStatusResponse | null>(null);
+    const [lastFestivalAction, setLastFestivalAction] = useState<"sync" | "retry" | "status" | null>(null);
+
 
     // 1. 회원 목록 조회 API
     const fetchMembers = useCallback(async () => {
@@ -168,10 +190,151 @@ export default function AdminPage() {
         }
     };
 
+    //축제 관리자 API 연결 함수 추가
+    const runFestivalSyncAndEnrich = async () => {
+        setFestivalActionLoading(true);
+        setFestivalActionError(null);
+        setFestivalActionMessage(null);
+
+        const accessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+
+        if (!accessToken) {
+            alert("로그인이 필요합니다.");
+            window.location.href = "/login";
+            return;
+        }
+
+        try {
+            const response = await fetch(
+                `/api/admin/festivals/sync-and-enrich?pageNo=1&numOfRows=300&eventStartDate=20260101`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        Accept: "application/json",
+                    },
+                }
+            );
+
+            const body = await response.json();
+
+            if (response.ok) {
+                setLastFestivalAction("sync");
+                setFestivalActionMessage(body.message || "축제 목록 동기화가 완료되었습니다.");
+                setFestivalSyncResult(body.data ?? null);
+                void fetchFestivalSyncStatus({ clearResult: false });
+            } else {
+                setFestivalActionError(body.message || "축제 동기화 실행에 실패했습니다.");
+                setFestivalSyncResult(null);
+            }
+        } catch (error) {
+            console.error("축제 동기화 실행 오류:", error);
+            setFestivalActionError("서버 통신 중 오류가 발생했습니다.");
+            setFestivalSyncResult(null);
+        } finally {
+            setFestivalActionLoading(false);
+        }
+    };
+
+    const runFestivalEnrichPending = async () => {
+        setFestivalActionLoading(true);
+        setFestivalActionError(null);
+        setFestivalActionMessage(null);
+
+        const accessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+
+        if (!accessToken) {
+            alert("로그인이 필요합니다.");
+            window.location.href = "/login";
+            return;
+        }
+
+        try {
+            const response = await fetch(`/api/admin/festivals/enrich-pending`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    Accept: "application/json",
+                },
+            });
+
+            const body = await response.json();
+
+            if (response.ok) {
+                setLastFestivalAction("retry");
+                setFestivalActionMessage(body.message || "축제 상세 보강 재처리가 완료되었습니다.");
+                setFestivalSyncResult(body.data ?? null);
+                void fetchFestivalSyncStatus({ clearResult: false });
+            } else {
+                setFestivalActionError(body.message || "축제 상세 재처리에 실패했습니다.");
+                setFestivalSyncResult(null);
+            }
+        } catch (error) {
+            console.error("축제 상세 재처리 오류:", error);
+            setFestivalActionError("서버 통신 중 오류가 발생했습니다.");
+            setFestivalSyncResult(null);
+        } finally {
+            setFestivalActionLoading(false);
+        }
+    };
+
+    const fetchFestivalSyncStatus = useCallback(
+        async (options?: { clearResult?: boolean }) => {
+            const clearResult = options?.clearResult ?? false;
+
+            setFestivalActionLoading(true);
+            setFestivalActionError(null);
+
+            if (clearResult) {
+                setFestivalSyncResult(null);
+                setLastFestivalAction("status");
+            }
+
+            const accessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+
+            if (!accessToken) {
+                alert("로그인이 필요합니다.");
+                window.location.href = "/login";
+                return;
+            }
+
+            try {
+                const response = await fetch(`/api/admin/festivals/sync-status`, {
+                    method: "GET",
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        Accept: "application/json",
+                    },
+                });
+
+                const body = await response.json();
+
+                if (response.ok) {
+                    setFestivalActionMessage(body.message || "동기화 상태 조회가 완료되었습니다.");
+                    setFestivalSyncStatus(body.data ?? null);
+                } else {
+                    setFestivalActionError(body.message || "동기화 상태 조회에 실패했습니다.");
+                    setFestivalSyncStatus(null);
+                }
+            } catch (error) {
+                console.error("축제 동기화 상태 조회 오류:", error);
+                setFestivalActionError("서버 통신 중 오류가 발생했습니다.");
+                setFestivalSyncStatus(null);
+            } finally {
+                setFestivalActionLoading(false);
+            }
+        },
+        []
+    );
+
     useEffect(() => {
         if (activeTab === "members") void fetchMembers();
         if (activeTab === "reviews") void fetchReportedReviews();
     }, [activeTab, fetchMembers, fetchReportedReviews]);
+
+    useEffect(() => {
+        if (activeTab === "festivals") void fetchFestivalSyncStatus({ clearResult: true });
+    }, [activeTab, fetchFestivalSyncStatus]);
 
     return (
         <div className="flex min-h-screen bg-slate-50">
@@ -367,15 +530,148 @@ export default function AdminPage() {
                     </div>
                 )}
 
+                {/*축제 데이터 관리*/}
                 {activeTab === "festivals" && (
                     <div className="animate-in fade-in duration-300">
-                        <h2 className="mb-6 text-2xl font-bold text-slate-800">축제 데이터 관리</h2>
-                        <div className="rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-                            <p className="text-slate-500">이 기능은 현재 준비 중입니다.</p>
+                        <div className="mb-6 flex items-center justify-between">
+                            <h2 className="text-2xl font-bold text-slate-800">축제 데이터 관리</h2>
+                            <span className="text-sm text-slate-500">동기화 및 상세 재처리 관리</span>
+                        </div>
+
+                        <div className="space-y-6">
+                            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                                <div className="flex flex-wrap gap-3">
+                                    <button
+                                        onClick={() => void runFestivalSyncAndEnrich()}
+                                        disabled={festivalActionLoading}
+                                        className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                        목록 동기화 실행
+                                    </button>
+
+                                    <button
+                                        onClick={() => void runFestivalEnrichPending()}
+                                        disabled={festivalActionLoading}
+                                        className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 text-sm font-semibold text-amber-700 transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                        상세 미완료 재처리
+                                    </button>
+
+                                    <button
+                                        onClick={() => void fetchFestivalSyncStatus({ clearResult: true })}
+                                        disabled={festivalActionLoading}
+                                        className="rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                        동기화 상태 조회
+                                    </button>
+                                </div>
+
+                                <p className="mt-4 text-sm text-slate-500">
+                                    목록 동기화 후 변경된 축제와 기존에 미반영된 축제의 상세 보강 상태를 관리합니다.
+                                </p>
+                            </div>
+
+                            {festivalActionLoading && (
+                                <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                                    <p className="text-sm text-slate-500">요청을 처리하는 중입니다...</p>
+                                </div>
+                            )}
+
+                            {festivalActionError && (
+                                <div className="rounded-xl border border-red-200 bg-red-50 p-6 shadow-sm">
+                                    <p className="text-sm font-medium text-red-600">{festivalActionError}</p>
+                                </div>
+                            )}
+
+                            {festivalActionMessage && (
+                                <div className="rounded-xl border border-blue-200 bg-blue-50 p-6 shadow-sm">
+                                    <p className="text-sm font-medium text-blue-700">{festivalActionMessage}</p>
+                                </div>
+                            )}
+
+                            {festivalSyncResult && lastFestivalAction !== "status" && (
+                                <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                                    <h3 className="mb-4 text-lg font-bold text-slate-800">
+                                        {lastFestivalAction === "retry"
+                                            ? "최근 상세 미완료 재처리 결과"
+                                            : "최근 목록 동기화 실행 결과"}
+                                    </h3>
+
+                                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                                        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                                            <p className="text-xs font-medium text-slate-500">전체 대상</p>
+                                            <p className="mt-2 text-2xl font-bold text-slate-900">
+                                                {festivalSyncResult.totalCount}
+                                            </p>
+                                        </div>
+
+                                        <div className="rounded-lg border border-green-200 bg-green-50 p-4">
+                                            <p className="text-xs font-medium text-green-700">생성</p>
+                                            <p className="mt-2 text-2xl font-bold text-green-800">
+                                                {festivalSyncResult.createdCount}
+                                            </p>
+                                        </div>
+
+                                        <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+                                            <p className="text-xs font-medium text-blue-700">수정</p>
+                                            <p className="mt-2 text-2xl font-bold text-blue-800">
+                                                {festivalSyncResult.updatedCount}
+                                            </p>
+                                        </div>
+
+                                        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+                                            <p className="text-xs font-medium text-red-700">실패</p>
+                                            <p className="mt-2 text-2xl font-bold text-red-800">
+                                                {festivalSyncResult.failedCount}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {festivalSyncStatus && (
+                                <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                                    <div className="mb-4 flex items-center justify-between">
+                                        <h3 className="text-lg font-bold text-slate-800">현재 상세 동기화 미완료 건수</h3>
+                                        <span
+                                            className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${
+                                                festivalSyncStatus.needsRetry
+                                                    ? "bg-amber-100 text-amber-700"
+                                                    : "bg-green-100 text-green-700"
+                                            }`}
+                                        >
+                            {festivalSyncStatus.needsRetry ? "재처리 필요" : "정상"}
+                        </span>
+                                    </div>
+
+                                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+                                        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                                            <p className="text-xs font-medium text-slate-500">전체 pending</p>
+                                            <p className="mt-2 text-2xl font-bold text-slate-900">
+                                                {festivalSyncStatus.pendingCount}
+                                            </p>
+                                        </div>
+
+                                        {Object.entries(festivalSyncStatus.pendingBreakdown).map(([key, value]) => (
+                                            <div
+                                                key={key}
+                                                className="rounded-lg border border-slate-200 bg-white p-4"
+                                            >
+                                                <p className="text-xs font-medium text-slate-500">{key}</p>
+                                                <p className="mt-2 text-2xl font-bold text-slate-900">{value}</p>
+                                            </div>
+                                        ))}
+                                    </div>
+
+                                    <p className="mt-4 text-sm text-slate-500">
+                                        해당 수치는 축제 상세 동기화 미완료 상태를 조회한 시점 기준입니다. RATE_LIMIT은 429 제한, SERVER_ERROR는 5xx 오류, EXCEPTION은 기타 예외,
+                                        UNPROCESSED는 중단 이후 미시도 대상을 의미합니다.
+                                    </p>
+                                </div>
+                            )}
                         </div>
                     </div>
                 )}
-
             </main>
         </div>
     );


### PR DESCRIPTION
### 1. 관리자 수동 축제 동기화 프론트 연동
* `/api/admin/festivals/sync-and-enrich` API를 통해
  * 목록 동기화
  * 상세 보강(enrich)
    을한 번의 요청으로 처리

* 응답 성공 시:
  * `FestivalSyncResult` 기반으로
  * 생성/수정/실패 건수 UI에 표시
---
### 2. 문제 발생
대량 데이터 동기화 시 다음 문제가 발생
#### ❗ 문제 1. 프론트 500 / 응답 실패
* `numOfRows`가 커질수록 요청 시간이 증가
* 브라우저 또는 3000 rewrite 구간에서 응답이 끊김
* 프론트에서는 500 또는 `Failed to fetch` 발생

#### ❗ 문제 2. 실제 데이터는 반영됨
* DB에는 정상적으로 데이터 반영
* 하지만 프론트는 실패로 인식
=>“실제 성공 vs 응답 실패” 불일치 발생

---
### 3. 문제 원인
* sync-and-enrich가 **동기식 + 대량 처리 구조**

* 한 요청에서:
  * 목록 조회
  * DB 반영
  * 상세 API 반복 호출
* → 응답 시간이 매우 길어짐

또한:
* 프론트는 **응답 결과에만 의존**
* 응답 실패 시 결과를 복구할 수 없음

---

### 4. 해결 방향 (현재 PR)

#### ✅ 1. 상태 기반 보정 로직 도입
응답 실패 시:
1. `sync-status` API 재조회
2. pendingCount 기준으로 상태 판단

* pending == 0 → 정상 반영 가능성 안내
* pending > 0 → 재처리 필요 안내
---

#### ✅ 2. 사용자 메시지 개선
기존:
* 단순 "서버 오류"
개선:
* 실제 상태 기반 안내

ex)
* "응답을 정상적으로 받지 못했지만, 현재 상세 동기화 미완료 대상은 없습니다."
* "상세 동기화 일부가 미완료 상태입니다. 재처리가 필요합니다."

---

#### ✅ 3. AbortController 도입

* 장시간 요청 시 프론트에서 최대 대기시간 제어
* timeout 발생 시 사용자에게 명확한 안내 제공
---

#### ✅ 4. 안전 파싱 적용
* JSON 파싱 실패 대응
* raw 응답 fallback 처리
---


## ⚠️ 현재 구조의 한계
* 동기식 처리 구조 유지
* 대량 데이터 시 응답 시간이 길어짐
* 자동 페이지 순회 없음 (백엔드 작업 브랜치에 구현 해놓긴 했습니다 필요하시면 올릴게요)
* 결과 summary는 응답에만 존재 (휘발성)
* **500 자체는 완전히 제거되지 않음**
* 대신 **UX적으로 보정**


---
## 🧪 테스트 시 주의사항
### 1. 요청 크기 조절 필수
numOfRows: 50 ~ 100 권장
```

* 큰 값(200~300) 사용 시:
응답 실패 가능성 높음
(응답 실패 ≠ 동기화 실패)
 500 발생해도: DB 반영될 수 있음
반드시 `sync-status`로 상태 확인 필요


## 🎯 결론
* 현재 구조에서 긴 요청 문제는 완전 해결이 어려움
* 대신:
  * 상태 기반 보정
  * 사용자 메시지 개선
  * fallback 처리
  * (500을 없앤 것”이 아니라 500이어도 사용자가 실제 상태를 알 수 있게 만든 것)
---

## 🔧 향후 개선 방향
* sync 결과 summary 별도 저장 API
* 자동 페이지 순회 도입
* 목록/상세 분리
* 비동기 처리 구조






