### PR TITLE
feat: 축제 찜하기(북마크) 및 취소 기능 구현 (상태 연동 포함)

### DIFF
--- a/src/app/festivals/[id]/page.tsx
+++ b/src/app/festivals/[id]/page.tsx
@@ -110,7 +110,14 @@ export default function FestivalDetailPage() {
     useEffect(() => {
         const fetchDetail = async () => {
             try {
-                const response = await fetch(`/api/festivals/${festivalId}`);
+                const token = typeof window !== "undefined" ? localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY) : null;
+                const response = await fetch(`/api/festivals/${festivalId}`, {
+                    cache: "no-store",
+                    headers: {
+                        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                        Accept: "application/json",
+                    },
+                });
                 const resData = await response.json();
                 if (
                     resData.status === 200 ||

--- a/src/app/festivals/page.tsx
+++ b/src/app/festivals/page.tsx
@@ -75,7 +75,14 @@ export default function MainPage() {
             params.append("page", currentPage.toString());
             params.append("size", "12"); // 백엔드 설정에 따라 조절 가능
 
-            const response = await fetch(`/api/festivals?${params.toString()}`);
+            const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+            const response = await fetch(`/api/festivals?${params.toString()}`, {
+                cache: "no-store",
+                headers: {
+                    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                    Accept: "application/json",
+                },
+            });
             const resData = await response.json();
 
             if (resData.resultCode === "200" || resData.status === "200") {
@@ -295,6 +302,11 @@ export default function MainPage() {
                                             initialIsBookmarked={festival.isBookmarked}
                                             isSmall={true}
                                             className="absolute top-3 right-3 z-10"
+                                            onToggle={(newStatus) => {
+                                                setFestivals(prev => prev.map(f =>
+                                                    f.id === festival.id ? { ...f, isBookmarked: newStatus } : f
+                                                ));
+                                            }}
                                         />
                                     </div>
 

--- a/src/components/BookMarkButton.tsx
+++ b/src/components/BookMarkButton.tsx
@@ -37,9 +37,21 @@ export default function BookmarkButton({
         setIsLoading(true);
 
         try {
+
+            const accessToken = localStorage.getItem("accessToken");
+            if (!accessToken) {
+                alert("로그인이 필요한 서비스입니다.");
+                setIsLoading(false);
+                return;
+            }
+
             const method = isBookmarked ? "DELETE" : "POST";
             const response = await fetch(`/api/festivals/${festivalId}/bookmark`, {
                 method: method,
+                headers: {                                              
+                    Authorization: `Bearer ${accessToken}`,                                                           
+                    Accept: "application/json",
+                },  
             });
 
             if (response.status === 401 || response.status === 403) {


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 사용자가 마음에 드는 축제를 '찜' 하고다시 취소할 수 있는 기능 FE 구현
- 실시간 카운트 연동을 통해 상세페이지 상단, 리스트페이지내의 찜 갯수에 즉시 반영되도록 동기화

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 상세페이지 우측 상단에 찜하기 버튼 배치
- `onToggle` 콜백 통해 상세 페이지 `bookMarkCount` 실시간 업데이트
- 비로그인 사용자 클릭시 알림 문구 노출
- 하트 아이콘 활성화/비활성화 구분

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
